### PR TITLE
enable v11

### DIFF
--- a/system.json
+++ b/system.json
@@ -137,6 +137,6 @@
   "compatibility": {
     "minimum": "10",
     "verified": "10",
-    "maximum": "10"
+    "maximum": "11"
   }
 }


### PR DESCRIPTION
makes mausritter installable on foundry v11