### PR TITLE
Localization Support Improvements

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -1,4 +1,20 @@
 {
+    "TYPES": {
+		"Actor": {
+			"character": "Character",
+			"hireling": "Hireling",
+			"creature": "Creature",
+			"storage": "Storage"
+		},
+		"Item": {
+			"item": "Item",
+			"weapon": "Weapon",
+			"armor": "Armor",
+			"storage": "Storage",
+			"condition": "Condition",
+			"spell": "Spell"
+		}
+	},
     "Maus.ActorName" : "Name",
     "Maus.ActorBackground" : "Background",
     "Maus.ActorWants" : "Wants",
@@ -19,7 +35,6 @@
     "Maus.Current" : "Current",
     "Maus.Strength" : "Strength",
     "Maus.Dexterity" : "Dexterity",
-
     "Maus.Will" : "Will",
     "Maus.Max" : "Max",
     "Maus.Pips" : "Pips",
@@ -63,6 +78,7 @@
     "Maus.Roll" : "Roll",
     "Maus.RollDescription" : "Description",
     "Maus.RollSelectStat" : "Select Stat",
+    "Maus.RollSelectType" : "Select Roll Type",
     "Maus.RollAdvantageDisadvantage" : "Advantage/Disadvantage",
     "Maus.RollAdvantage" : "Advantage",
     "Maus.RollDisadvantage" : "Disadvantage",
@@ -73,8 +89,10 @@
     "Maus.RollEnhanced" : "Enhanced",
     "Maus.RollImpaired" : "Impaired",
     "Maus.RollPowerDesc" : "How much Power?",
-    "Maus.RollSum" : "Sum",
+    "Maus.RollSum" : "Sum", 
     "Maus.RollDice" : "Dice",
+    "Maus.RollSumKeyword": "[SUM]",
+    "Maus.RollDiceKeyword": "[DICE]", 
     "Maus.RollUsage" : "Usage",
     "Maus.RollDamage" : "Damage",
     "Maus.RollTarget" : "Target",

--- a/module/actor/actor.js
+++ b/module/actor/actor.js
@@ -43,15 +43,14 @@ export class MausritterActor extends Actor {
 
     let selectList = "";
 
-    statList.forEach(stat => selectList += "<option value='" + stat[0] + "'>" + stat[1].label + "</option>")
+    statList.forEach(stat => selectList += "<option value='" + stat[0] + "'>" + game.i18n.localize('Maus.'+stat[1].label) + "</option>")
 
     let d = new Dialog({
-      title: "Select Roll Type",
-      content: "<h2> Stat </h2> <select style='margin-bottom:10px;'name='stat' id='stat'> " + selectList + "</select> <br/>",
+      title: game.i18n.localize('Maus.RollSelectType'),
+      content: "<h2>" + game.i18n.localize('Maus.RollSelectStat') + "</h2> <select style='margin-bottom:10px;'name='stat' id='stat'> " + selectList + "</select> <br/>",
       buttons: {
         roll: {
           icon: '<i class="fas fa-check"></i>',
-
           label: game.i18n.localize('Maus.Roll'),
           callback: (html) => this.rollStat(this.system.stats[html.find('[id=\"stat\"]')[0].value])
         },
@@ -76,7 +75,7 @@ export class MausritterActor extends Actor {
     //this.rollAttribute(attribute, "none");
 
     let d = new Dialog({
-      title: "Select Roll Type",
+      title: game.i18n.localize('Maus.RollSelectType'),
       content: "<h2> "+game.i18n.localize('Maus.RollAdvantageDisadvantage')+ "</h2> <select style='margin-bottom:10px;'name='advantage' id='advantage'> <option value='none'>"+game.i18n.localize('Maus.RollNone')+"</option> <option value='advantage'>"+game.i18n.localize('Maus.RollAdvantageDisadvantage')+"</option></select> <br/>",
       buttons: {
         roll: {
@@ -196,7 +195,7 @@ export class MausritterActor extends Actor {
       rollTitle: game.i18n.localize('Maus.RollDamage'), //The title of the roll.
       rollText: damageRoll._total, //What is printed within the roll amount.
       damageDice: die,
-      weaponState: state,
+      weaponState: game.i18n.localize('Maus.Roll' + state.charAt(0).toUpperCase() + state.slice(1)), 
       isWeapon: true,
       diceData
     };
@@ -257,9 +256,9 @@ export class MausritterActor extends Actor {
     if(item.system.description == null){
       item.system.description = "";
     }
-
-    item.system.description = item.system.description.split("[DICE]").join("<strong style='text-decoration:underline' class='red'>"+power+"</strong>");
-    item.system.description = item.system.description.split("[SUM]").join("<strong style='text-decoration:underline' class='red'>"+damageRoll._total+"</strong>");
+  
+    item.system.description = item.system.description.split(game.i18n.localize('Maus.RollDiceKeyword')).join("<strong style='text-decoration:underline' class='red'>"+power+"</strong>");
+    item.system.description = item.system.description.split(game.i18n.localize('Maus.RollSumKeyword')).join("<strong style='text-decoration:underline' class='red'>"+damageRoll._total+"</strong>");
     item.system.description += "<h2>"+game.i18n.localize('Maus.RollUsage')+": <strong>"+usage+"</strong></h2>";
     if(miscast){
       let miscastDesc = game.i18n.localize('Maus.RollMiscastDesc');

--- a/module/actor/create-character/create-character.js
+++ b/module/actor/create-character/create-character.js
@@ -99,11 +99,11 @@ async function createStats(background, basicStats, details) {
     const pips = !!background ? background.pips : 0;
     const hp = !!background ? background.hp : 0;
 
-    const birthSign = details ? await drawFromTable("Birthsign") : '';
-    const look = details ? await drawFromTable("Physical detail") : '';
-    const coat = details ? await drawFromTable("Mousy Coat Pattern") + " " + await drawFromTable("Mousy Coat Color") : '';
+    const birthSign = details ? await drawFromTable(CONFIG.MAUSRITTER.tables.birthsign) : '';
+    const look = details ? await drawFromTable(CONFIG.MAUSRITTER.tables.physicalDetail) : '';
+    const coat = details ? await drawFromTable(CONFIG.MAUSRITTER.tables.coatPattern) + " " + await drawFromTable(CONFIG.MAUSRITTER.tables.coatColor) : '';
 
-    const name = getRandomName();
+    const name = await getRandomName();
 
     return {
         name: name,
@@ -162,8 +162,8 @@ function getHighestAttrValue(stats) {
     return Math.max(...[stats.dexterity.max, stats.will.max, stats.strength.max])
 }
 
-function getRandomName() {
-    const firstName = FIRST_NAMES[Math.floor(Math.random() * FIRST_NAMES.length)]
-    const lastName = LAST_NAMES[Math.floor(Math.random() * LAST_NAMES.length)]
+async function getRandomName() {
+    const firstName = await drawFromTable(CONFIG.MAUSRITTER.tables.firstName)
+    const lastName = await drawFromTable(CONFIG.MAUSRITTER.tables.lastName)
     return firstName + " " + lastName
 }

--- a/module/actor/create-character/foundry-clinet.js
+++ b/module/actor/create-character/foundry-clinet.js
@@ -20,7 +20,7 @@ export function attrRoll() {
 
 export async function drawFromTable(tableName) {
     const listCompendium = await game.packs.filter(p => p.documentName === 'RollTable');
-    const compendiumTables = await listCompendium.filter(p => p.metadata.label === 'Tables')
+    const compendiumTables = await listCompendium.filter(p => p.metadata.label === CONFIG.MAUSRITTER.tables.tables)
     if (compendiumTables.length===0) {
         ui.notifications.warn(`Table ${tableName} not found.`, {});
         return;

--- a/module/mausritter.js
+++ b/module/mausritter.js
@@ -38,8 +38,20 @@ Hooks.once('init', async function () {
   // Define custom Entity classes
   CONFIG.Actor.documentClass = MausritterActor;
   CONFIG.Item.documentClass = MausritterItem;
+ 
+  // Define table data for character generator
+  CONFIG.MAUSRITTER = {}
 
-
+  CONFIG.MAUSRITTER.tables = {
+    tables: "Tables",
+    birthsign: "Birthsign",
+    physicalDetail: "Physical detail",
+    coatPattern: "Mousy Coat Pattern",
+    coatColor: "Mousy Coat Color",
+    firstName: "Mousy Names - Birthname",
+    lastName: "Mousy Names - Matriname"
+  }
+  
   // Register sheet application classes
   Actors.unregisterSheet("core", ActorSheet);
 


### PR DESCRIPTION
Added localization support to many parts of the system.
**All existing localizations (and English) are fully compatible** but may use new features to expand and improve translation.

1. Character Generator now uses tables set in the `CONFIG.MAUSRITTER` instead of hardcoded table names.
2. Changed logic of First/Last name randomizer to use existing roll table of names instead of hardcoded list.
3. Translation support for Actor and Item types ("Create New" dialog).
4. Translated Roll Stat macro.
5. Added localization support for `[DICE]` and `[SUM]` keywords.
6. Localized roll modifiers (Enhanced, Impaired, Normal) in chat cards.