### PR TITLE
Update system.json

### DIFF
--- a/system.json
+++ b/system.json
@@ -144,8 +144,10 @@
       "flags": {}
     }
   ],
-  "gridDistance": 1,
-  "gridUnits": "in",
+  "grid": {
+    "units": "in",
+    "distance": 1
+  },
   "primaryTokenAttribute": "health",
   "url": "https://github.com/Futil/foundry-mausritter",
   "manifest": "https://raw.githubusercontent.com/Futil/foundry-mausritter/v10/system.json",


### PR DESCRIPTION
Fix for warning:

>The system "mausritter" is using "gridDistance" which is deprecated in favor of "grid.distance".
>The system "mausritter" is using "gridUnits" which is deprecated in favor of "grid.units".