### PR TITLE
fix: mergeobject deprecation warning

### DIFF
--- a/module/actor/actor-sheet.js
+++ b/module/actor/actor-sheet.js
@@ -6,7 +6,7 @@ export class MausritterActorSheet extends ActorSheet {
 
     /** @override */
     static get defaultOptions() {
-        return foundry.utils.mergeObject(super.defaultOptions, {
+        return foundry.utils.foundry.utils.mergeObject(super.defaultOptions, {
             classes: ["mausritter", "sheet", "actor", "character"],
             template: "systems/mausritter/templates/actor/actor-sheet.html",
             width: 742,

--- a/module/actor/creature-sheet.js
+++ b/module/actor/creature-sheet.js
@@ -7,7 +7,7 @@ export class MausritterCreatureSheet extends ActorSheet {
 
     /** @override */
     static get defaultOptions() {
-        return mergeObject(super.defaultOptions, {
+        return foundry.utils.mergeObject(super.defaultOptions, {
             classes: ["mausritter", "sheet", "actor", "creature"],
             template: "systems/mausritter/templates/actor/creature-sheet.html",
             width: 680,

--- a/module/actor/hireling-sheet.js
+++ b/module/actor/hireling-sheet.js
@@ -7,7 +7,7 @@ export class MausritterHirelingSheet extends ActorSheet {
 
   /** @override */
   static get defaultOptions() {
-    return mergeObject(super.defaultOptions, {
+    return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["mausritter", "sheet", "actor", "hireling"],
       template: "systems/mausritter/templates/actor/hireling-sheet.html",
       width: 680,

--- a/module/actor/storage-sheet.js
+++ b/module/actor/storage-sheet.js
@@ -7,7 +7,7 @@ export class MausritterStorageSheet extends ActorSheet {
 
     /** @override */
     static get defaultOptions() {
-        return mergeObject(super.defaultOptions, {
+        return foundry.utils.mergeObject(super.defaultOptions, {
             classes: ["mausritter", "sheet", "actor", "storage"],
             template: "systems/mausritter/templates/actor/storage-sheet.html",
             width: 475,

--- a/module/item/item-sheet.js
+++ b/module/item/item-sheet.js
@@ -6,7 +6,7 @@ export class MausritterItemSheet extends ItemSheet {
 
   /** @override */
   static get defaultOptions() {
-    return mergeObject(super.defaultOptions, {
+    return foundry.utils.mergeObject(super.defaultOptions, {
       classes: ["mausritter", "sheet", "item"],
       width: 520,
       height: 480,

--- a/module/mausritter.js
+++ b/module/mausritter.js
@@ -109,7 +109,7 @@ Hooks.once('init', async function () {
   }
 
   // Set wounds, advantage, and display name visibility
-  mergeObject(createData,
+  foundry.utils.mergeObject(createData,
     {
       "token.bar1": { "attribute": "health" },        // Default Bar 1 to Health 
       "token.bar2": { "stat": "strength" },      // Default Bar 2 to Insanity


### PR DESCRIPTION
Fix some deprecation warnings. I noticed them when using the character creator macro.

![mergeObject-deprecation-warning](https://github.com/user-attachments/assets/c8500c74-1a25-4c6c-8ba5-f03e4b71764b)
